### PR TITLE
Allows yaml files to also be downloaded from the cloud

### DIFF
--- a/services/backend/Dockerfile
+++ b/services/backend/Dockerfile
@@ -138,9 +138,9 @@ RUN /bin/bash -c "source /opt/ros/jazzy/setup.bash && \
 #     && chmod +x src/ai-navigation/motor_control/resource/docker_startup_script.sh \
 #     && ./src/ai-navigation/motor_control/resource/docker_startup_script.sh
 
-# Get maps
+# Get maps & config files
 RUN mkdir -p /maps && \
-    wget -q -r -nd -l1 -A pcd -P /maps https://w3.cs.jmu.edu/spragunr/rosmaps/
+    wget -q -r -np -nd -l1 -P /maps -A "*.yaml,*.pcd" https://w3.cs.jmu.edu/spragunr/rosmaps/
 
 # Get student auth setup script
 RUN wget -O /root/student_auth_setup.sh https://raw.githubusercontent.com/JACart2/docker_files/main/student_auth_setup.sh && \


### PR DESCRIPTION
# Pull Request

## Linked Issue

Closes #104 from Navigation and Routing S26

---

# Summary

When building the docker and containers, yaml files in https://w3.cs.jmu.edu/spragunr/rosmaps/, such as config landmark files for coordinate conversion is also now included.

---

# Testing Summary

Testing exclusive to the changes only on this branch are complete and successful.

Tests related to ai-navigation are mutual with branch Sun/Coordinate-Conversion-2. See the pull request handling that branch to see other tests related to calibration and coordinate conversion.

---

# Testing Instructions

1. Build the environment using ./dev_run_backend.sh
2. Check for the existence of SpeedBoiMap.yaml with ls -la /maps.

---

# Success Metrics (From Issue)

If SpeedBoiMap.yaml has been successfully downloaded after building the container environment.

---

# Integration Impact

This is a required merge before merging the branch on Sun/Coordinate-Conversion-2, which relies on this functionality to access the calibration files. Otherwise does not affect other systems.


