### PR TITLE
Update backend command to launch multiple ROS2 nodes

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -7,7 +7,7 @@ services:
     build:
       context: ./services/backend/
       dockerfile: ./Dockerfile
-    command: ros2 launch cart_launch autonomous_launcher.launch.py #can be overriden with $BACKEND_COMMAND
+    command: bash -c "ros2 launch rosbridge_server rosbridge_websocket_launch.xml & ros2 launch cart_launch autonomous_launcher.launch.py" #can be overriden with $BACKEND_COMMAND
     environment:
       - BACKEND_COMMAND #will override the default command above
       - ROS_DOMAIN_ID=0


### PR DESCRIPTION
# Pull Request

## Linked Issue

Closes #19 

---

# Summary

runs both "ros2 launch rosbridge_server rosbridge_websocket_launch.xml & ros2 launch cart_launch autonomous_launcher.launch.py" 

---

# Testing Summary

Briefly describe:
 Runs ./run.sh
 
 Ensure rosbridge_websocket is running

---

# Testing Instructions

Running the ./run.sh command

make sure the rosbridge_websocket appears in ros2 topics.

---

# Success Metrics (From Issue)

List the concrete success metrics defined in the issue and explain how
they are satisfied.

- [x] Metric 1: rosbridge_websocket appears and allows connection to https://github.com/JACart2/dashboard

---

# Integration Impact
None




