### PR TITLE
Dashboard api call

### DIFF
--- a/dev-run-backend.sh
+++ b/dev-run-backend.sh
@@ -1,25 +1,73 @@
 #!/bin/bash
 
+# -------------------------
+# Config (override via env)
+# -------------------------
+CART_NAME="${CART_NAME:-james}"
+SERVER_IP="${SERVER_IP:-10.247.225.41}"   # Dashboard server (external)
+CART_PORT="${CART_PORT:-9090}"
+API_PORT="${API_PORT:-8000}"
+
+# How often to *probe* the dashboard when it's down / between attempts
+REREGISTER_INTERVAL_SEC="${REREGISTER_INTERVAL_SEC:-15}"
+# Minimum time between successful registrations
+REGISTER_COOLDOWN_SEC="${REGISTER_COOLDOWN_SEC:-15}"   # 15 seconds
+
 bash ./initialize_host.sh
 
-open_browser_when_ready () {
-	until curl -s http://localhost:5173 > /dev/null
-	do
-	# This is just waiting for the application to start. If the container is not up and running, this will wait forever.
-	#   echo "Waiting for port 5173 to open."
-	  sleep 2
-	done
-	if command -v open &> /dev/null; then
-		open http://localhost:5173
-	else
-		xdg-open http://localhost:5173
-	fi
+wait_for_frontend () {
+    until curl -fsS http://localhost:5173 >/dev/null 2>&1
+    do
+        sleep 2
+    done
 }
 
+dashboard_up () {
+  # Only check, don't fail script if dashboard is unreachable
+  curl -fsS "http://${SERVER_IP}:${API_PORT}/" >/dev/null 2>&1
+}
+
+register_cart () {
+  # Ignore failure, always return true
+  curl -fsS -X POST "http://${SERVER_IP}:${API_PORT}/api/vehicles/register" \
+    -H "Content-Type: application/json" \
+    -d "{\"name\":\"${CART_NAME}\",\"port\":${CART_PORT}}" >/dev/null 2>&1 || true
+}
+
+reregister_loop () {
+  local last_ok=0
+  while true; do
+    if dashboard_up; then
+      local now
+      now="$(date +%s)"
+
+      # only re-register if we haven't done so recently
+      if (( now - last_ok >= REGISTER_COOLDOWN_SEC )); then
+        register_cart
+        last_ok="$now"
+      fi
+    fi
+
+    sleep "$REREGISTER_INTERVAL_SEC"
+  done
+}
+
+open_browser_when_ready () {
+    wait_for_frontend
+    if command -v open &> /dev/null; then
+        open http://localhost:5173
+    else
+        xdg-open http://localhost:5173
+    fi
+}
+
+# Start opening browser when frontend is ready (background)
 open_browser_when_ready &
 
+# Start periodic re-registration in background
+reregister_loop &
+
 # Start the frontend with its default command, and stall the backend.
-# We set FRONTEND_COMMAND to empty (or unset) to trigger the default behavior in entrypoint.sh/compose.yaml
 BACKEND_COMMAND="tail -f /dev/null" docker compose up frontend backend -d --build --remove-orphans --force-recreate
 
 # Launch VS Code attached to the container
@@ -37,4 +85,5 @@ if command -v code &> /dev/null; then
 fi
 
 # Attach a terminal to the backend
-docker compose exec -it -w /root/dev_ws backend bash -c 'source /opt/ros/jazzy/setup.bash && source /opt/ros_ws/install/setup.bash && ([ -f /root/dev_ws/install/setup.bash ] && source /root/dev_ws/install/setup.bash); exec bash'
+docker compose exec -it -w /root/dev_ws backend bash -c \
+  'source /opt/ros/jazzy/setup.bash && source /opt/ros_ws/install/setup.bash && ([ -f /root/dev_ws/install/setup.bash ] && source /root/dev_ws/install/setup.bash); exec bash'

--- a/run.sh
+++ b/run.sh
@@ -1,17 +1,36 @@
 #!/bin/bash
 
+# -------------------------
+# Config (override via env)
+# -------------------------
+CART_NAME="${CART_NAME:-james}"
+SERVER_IP="${SERVER_IP:-10.247.225.41}" # Current ZeroTier IP for dashboard
+CART_PORT="${CART_PORT:-9090}" # Default rosbridge port
+API_PORT="${API_PORT:-8000}" # Port for dashboard server
+
 bash ./initialize_host.sh
 
 open_browser_when_ready () {
 	until curl -s http://localhost:5173 > /dev/null
 	do
-	# This is just waiting for the application to start. If the container is not up and running, this will wait forever.
-	#   echo "Waiting for port 5173 to open."
 	  sleep 2
 	done
 	open http://localhost:5173
 }
 
-open_browser_when_ready & docker compose up backend frontend --build --remove-orphans --force-recreate 
+register_cart_when_ready () {
+  # Wait until the server answers on port 8000 (adjust path if needed)
+  until curl -s "http://${SERVER_IP}:${API_PORT}/" > /dev/null
+  do
+    sleep 2
+  done
 
+  curl -X POST "http://${SERVER_IP}:${API_PORT}/api/vehicles/register" \
+    -H "Content-Type: application/json" \
+    -d "{\"name\":\"${CART_NAME}\",\"port\":${CART_PORT}}"
+}
 
+open_browser_when_ready &
+register_cart_when_ready &
+
+docker compose up backend frontend --build --remove-orphans --force-recreate

--- a/run.sh
+++ b/run.sh
@@ -10,9 +10,9 @@ CART_PORT="${CART_PORT:-9090}"
 API_PORT="${API_PORT:-8000}"
 
 # How often to *probe* the dashboard when it's down / between attempts
-REREGISTER_INTERVAL_SEC="${REREGISTER_INTERVAL_SEC:-30}"
+REREGISTER_INTERVAL_SEC="${REREGISTER_INTERVAL_SEC:-15}"
 # Minimum time between successful registrations
-REGISTER_COOLDOWN_SEC="${REGISTER_COOLDOWN_SEC:-300}"   # 5 minutes
+REGISTER_COOLDOWN_SEC="${REGISTER_COOLDOWN_SEC:-15}"   # 15 seconds
 
 bash ./initialize_host.sh
 

--- a/run.sh
+++ b/run.sh
@@ -17,22 +17,23 @@ REGISTER_COOLDOWN_SEC="${REGISTER_COOLDOWN_SEC:-15}"   # 15 seconds
 bash ./initialize_host.sh
 
 wait_for_frontend () {
-  until curl -fsS http://localhost:5173 >/dev/null; do
+  until curl -fsS http://localhost:5173 >/dev/null 2>&1; do
     sleep 2
   done
 }
 
 dashboard_up () {
-  curl -fsS "http://${SERVER_IP}:${API_PORT}/" >/dev/null
+  # Only check, don't fail script if dashboard is unreachable
+  curl -fsS "http://${SERVER_IP}:${API_PORT}/" >/dev/null 2>&1
 }
 
 register_cart () {
+  # Ignore failure, always return true
   curl -fsS -X POST "http://${SERVER_IP}:${API_PORT}/api/vehicles/register" \
     -H "Content-Type: application/json" \
-    -d "{\"name\":\"${CART_NAME}\",\"port\":${CART_PORT}}"
+    -d "{\"name\":\"${CART_NAME}\",\"port\":${CART_PORT}}" >/dev/null 2>&1 || true
 }
 
-# Background loop: if dashboard is up, try (re)registering occasionally
 reregister_loop () {
   local last_ok=0
   while true; do
@@ -42,9 +43,8 @@ reregister_loop () {
 
       # only re-register if we haven't done so recently
       if (( now - last_ok >= REGISTER_COOLDOWN_SEC )); then
-        if register_cart; then
-          last_ok="$now"
-        fi
+        register_cart
+        last_ok="$now"
       fi
     fi
 

--- a/run.sh
+++ b/run.sh
@@ -6,8 +6,13 @@ set -e
 # -------------------------
 CART_NAME="${CART_NAME:-james}"
 SERVER_IP="${SERVER_IP:-10.247.225.41}"   # Dashboard server (external)
-CART_PORT="${CART_PORT:-9090}"            # rosbridge port
-API_PORT="${API_PORT:-8000}"              # dashboard server port
+CART_PORT="${CART_PORT:-9090}"
+API_PORT="${API_PORT:-8000}"
+
+# How often to *probe* the dashboard when it's down / between attempts
+REREGISTER_INTERVAL_SEC="${REREGISTER_INTERVAL_SEC:-30}"
+# Minimum time between successful registrations
+REGISTER_COOLDOWN_SEC="${REGISTER_COOLDOWN_SEC:-300}"   # 5 minutes
 
 bash ./initialize_host.sh
 
@@ -17,11 +22,8 @@ wait_for_frontend () {
   done
 }
 
-wait_for_dashboard () {
-  # external dashboard server availability check
-  until curl -fsS "http://${SERVER_IP}:${API_PORT}/" >/dev/null; do
-    sleep 2
-  done
+dashboard_up () {
+  curl -fsS "http://${SERVER_IP}:${API_PORT}/" >/dev/null
 }
 
 register_cart () {
@@ -30,22 +32,36 @@ register_cart () {
     -d "{\"name\":\"${CART_NAME}\",\"port\":${CART_PORT}}"
 }
 
+# Background loop: if dashboard is up, try (re)registering occasionally
+reregister_loop () {
+  local last_ok=0
+  while true; do
+    if dashboard_up; then
+      local now
+      now="$(date +%s)"
+
+      # only re-register if we haven't done so recently
+      if (( now - last_ok >= REGISTER_COOLDOWN_SEC )); then
+        if register_cart; then
+          last_ok="$now"
+        fi
+      fi
+    fi
+
+    sleep "$REREGISTER_INTERVAL_SEC"
+  done
+}
+
 # Start containers
 docker compose up backend frontend --build --remove-orphans --force-recreate &
 COMPOSE_PID=$!
 
-# Wait for the frontend dev server, then open browser
+# Wait for frontend then open browser
 wait_for_frontend
 open "http://localhost:5173"
 
-# After browser opens: wait for dashboard, then register (without blocking compose logs)
-(
-  wait_for_dashboard
-  # optionally retry registration until it works
-  until register_cart; do
-    sleep 2
-  done
-) &
+# Start periodic re-registration in background
+reregister_loop &
 
-# Keep attached to docker compose
+# Keep attached to compose
 wait "$COMPOSE_PID"

--- a/run.sh
+++ b/run.sh
@@ -1,36 +1,48 @@
 #!/bin/bash
+set -e
 
 # -------------------------
 # Config (override via env)
 # -------------------------
 CART_NAME="${CART_NAME:-james}"
-SERVER_IP="${SERVER_IP:-10.247.225.41}" # Current ZeroTier IP for dashboard
-CART_PORT="${CART_PORT:-9090}" # Default rosbridge port
-API_PORT="${API_PORT:-8000}" # Port for dashboard server
+SERVER_IP="${SERVER_IP:-10.247.225.41}"
+CART_PORT="${CART_PORT:-9090}"
+API_PORT="${API_PORT:-8000}"
 
 bash ./initialize_host.sh
 
-open_browser_when_ready () {
-	until curl -s http://localhost:5173 > /dev/null
-	do
-	  sleep 2
-	done
-	open http://localhost:5173
-}
-
-register_cart_when_ready () {
-  # Wait until the server answers on port 8000 (adjust path if needed)
-  until curl -s "http://${SERVER_IP}:${API_PORT}/" > /dev/null
-  do
+wait_for_frontend () {
+  until curl -fsS http://localhost:5173 >/dev/null; do
     sleep 2
   done
+}
 
-  curl -X POST "http://${SERVER_IP}:${API_PORT}/api/vehicles/register" \
+wait_for_backend () {
+  # waits until the backend API is answering
+  until curl -fsS "http://${SERVER_IP}:${API_PORT}/" >/dev/null; do
+    sleep 2
+  done
+}
+
+register_cart () {
+  curl -fsS -X POST "http://${SERVER_IP}:${API_PORT}/api/vehicles/register" \
     -H "Content-Type: application/json" \
     -d "{\"name\":\"${CART_NAME}\",\"port\":${CART_PORT}}"
 }
 
-open_browser_when_ready &
-register_cart_when_ready &
+# Start containers, but keep the script running
+docker compose up backend frontend --build --remove-orphans --force-recreate &
+COMPOSE_PID=$!
 
-docker compose up backend frontend --build --remove-orphans --force-recreate
+# Wait specifically for backend to be usable (not for docker compose to "finish", because `up` runs forever)
+wait_for_backend
+
+# Optionally also wait for frontend before opening browser
+wait_for_frontend
+open "http://localhost:5173"
+
+# Now that backend is up, do the API call
+register_cart
+
+# Keep streaming compose logs / keep containers attached like normal
+wait "$COMPOSE_PID"

--- a/run.sh
+++ b/run.sh
@@ -5,9 +5,9 @@ set -e
 # Config (override via env)
 # -------------------------
 CART_NAME="${CART_NAME:-james}"
-SERVER_IP="${SERVER_IP:-10.247.225.41}"
-CART_PORT="${CART_PORT:-9090}"
-API_PORT="${API_PORT:-8000}"
+SERVER_IP="${SERVER_IP:-10.247.225.41}"   # Dashboard server (external)
+CART_PORT="${CART_PORT:-9090}"            # rosbridge port
+API_PORT="${API_PORT:-8000}"              # dashboard server port
 
 bash ./initialize_host.sh
 
@@ -17,8 +17,8 @@ wait_for_frontend () {
   done
 }
 
-wait_for_backend () {
-  # waits until the backend API is answering
+wait_for_dashboard () {
+  # external dashboard server availability check
   until curl -fsS "http://${SERVER_IP}:${API_PORT}/" >/dev/null; do
     sleep 2
   done
@@ -30,19 +30,22 @@ register_cart () {
     -d "{\"name\":\"${CART_NAME}\",\"port\":${CART_PORT}}"
 }
 
-# Start containers, but keep the script running
+# Start containers
 docker compose up backend frontend --build --remove-orphans --force-recreate &
 COMPOSE_PID=$!
 
-# Wait specifically for backend to be usable (not for docker compose to "finish", because `up` runs forever)
-wait_for_backend
-
-# Optionally also wait for frontend before opening browser
+# Wait for the frontend dev server, then open browser
 wait_for_frontend
 open "http://localhost:5173"
 
-# Now that backend is up, do the API call
-register_cart
+# After browser opens: wait for dashboard, then register (without blocking compose logs)
+(
+  wait_for_dashboard
+  # optionally retry registration until it works
+  until register_cart; do
+    sleep 2
+  done
+) &
 
-# Keep streaming compose logs / keep containers attached like normal
+# Keep attached to docker compose
 wait "$COMPOSE_PID"


### PR DESCRIPTION
# Pull Request

## Linked Issue

Closes N/A

---

# Summary

Automatically makes an api request to dashboard server, api request is not called until browser is open

---

# Testing Summary

Cart still launches normally, cart attempts api request every 15 seconds to dashboard server, api request is reestablished after shutting down dashboard and rebooting it.

# Testing Instructions

Run ./run.sh

No changes should be visible on computer running ./run.sh

Dashboard webpage in DevTools console and terminal running npm run dev should see api responses from cart

# Integration Impact

Should not interfere with launch of frontend and backend container




