### PR TITLE
Use npm ci for installing dependencies

### DIFF
--- a/services/frontend/entrypoint.sh
+++ b/services/frontend/entrypoint.sh
@@ -11,7 +11,7 @@ if [ -d ".git" ]; then
 fi
 
 echo "Installing npm dependencies..."
-npm install
+npm ci --prefer-offline --no-audit
 
 if [[ -n "$FRONTEND_COMMAND" ]]; then
   exec bash -lc "$FRONTEND_COMMAND"


### PR DESCRIPTION
Replaced 'npm install' with 'npm ci' for better dependency management.

# Pull Request

## Linked Issue
N/A

---

# Summary
Fixes frontend container npm ENOEMPTY error, crashing the container.
---

# Testing Summary
Frontend container launches normally from ./run.sh or ./dev-run-backend.sh

---

# Testing Instructions
Launch JACart normally from ./run.sh or ./dev-run-backend.sh


---

# Success Metrics (From Issue)
N/A

---

# Integration Impact
N/A


