### PR TITLE
Summer2026

### DIFF
--- a/dev-run-backend.sh
+++ b/dev-run-backend.sh
@@ -1,25 +1,73 @@
 #!/bin/bash
 
+# -------------------------
+# Config (override via env)
+# -------------------------
+CART_NAME="${CART_NAME:-james}"
+SERVER_IP="${SERVER_IP:-10.247.225.41}"   # Dashboard server (external)
+CART_PORT="${CART_PORT:-9090}"
+API_PORT="${API_PORT:-8000}"
+
+# How often to *probe* the dashboard when it's down / between attempts
+REREGISTER_INTERVAL_SEC="${REREGISTER_INTERVAL_SEC:-15}"
+# Minimum time between successful registrations
+REGISTER_COOLDOWN_SEC="${REGISTER_COOLDOWN_SEC:-15}"   # 15 seconds
+
 bash ./initialize_host.sh
 
-open_browser_when_ready () {
-	until curl -s http://localhost:5173 > /dev/null
-	do
-	# This is just waiting for the application to start. If the container is not up and running, this will wait forever.
-	#   echo "Waiting for port 5173 to open."
-	  sleep 2
-	done
-	if command -v open &> /dev/null; then
-		open http://localhost:5173
-	else
-		xdg-open http://localhost:5173
-	fi
+wait_for_frontend () {
+    until curl -fsS http://localhost:5173 >/dev/null 2>&1
+    do
+        sleep 2
+    done
 }
 
+dashboard_up () {
+  # Only check, don't fail script if dashboard is unreachable
+  curl -fsS "http://${SERVER_IP}:${API_PORT}/" >/dev/null 2>&1
+}
+
+register_cart () {
+  # Ignore failure, always return true
+  curl -fsS -X POST "http://${SERVER_IP}:${API_PORT}/api/vehicles/register" \
+    -H "Content-Type: application/json" \
+    -d "{\"name\":\"${CART_NAME}\",\"port\":${CART_PORT}}" >/dev/null 2>&1 || true
+}
+
+reregister_loop () {
+  local last_ok=0
+  while true; do
+    if dashboard_up; then
+      local now
+      now="$(date +%s)"
+
+      # only re-register if we haven't done so recently
+      if (( now - last_ok >= REGISTER_COOLDOWN_SEC )); then
+        register_cart
+        last_ok="$now"
+      fi
+    fi
+
+    sleep "$REREGISTER_INTERVAL_SEC"
+  done
+}
+
+open_browser_when_ready () {
+    wait_for_frontend
+    if command -v open &> /dev/null; then
+        open http://localhost:5173
+    else
+        xdg-open http://localhost:5173
+    fi
+}
+
+# Start opening browser when frontend is ready (background)
 open_browser_when_ready &
 
+# Start periodic re-registration in background
+reregister_loop &
+
 # Start the frontend with its default command, and stall the backend.
-# We set FRONTEND_COMMAND to empty (or unset) to trigger the default behavior in entrypoint.sh/compose.yaml
 BACKEND_COMMAND="tail -f /dev/null" docker compose up frontend backend -d --build --remove-orphans --force-recreate
 
 # Launch VS Code attached to the container
@@ -37,4 +85,5 @@ if command -v code &> /dev/null; then
 fi
 
 # Attach a terminal to the backend
-docker compose exec -it -w /root/dev_ws backend bash -c 'source /opt/ros/jazzy/setup.bash && source /opt/ros_ws/install/setup.bash && ([ -f /root/dev_ws/install/setup.bash ] && source /root/dev_ws/install/setup.bash); exec bash'
+docker compose exec -it -w /root/dev_ws backend bash -c \
+  'source /opt/ros/jazzy/setup.bash && source /opt/ros_ws/install/setup.bash && ([ -f /root/dev_ws/install/setup.bash ] && source /root/dev_ws/install/setup.bash); exec bash'

--- a/dev-run-backend.sh
+++ b/dev-run-backend.sh
@@ -1,12 +1,19 @@
 #!/bin/bash
 
-# -------------------------
 # Config (override via env)
-# -------------------------
 CART_NAME="${CART_NAME:-james}"
 SERVER_IP="${SERVER_IP:-10.247.225.41}"   # Dashboard server (external)
 CART_PORT="${CART_PORT:-9090}"
 API_PORT="${API_PORT:-8000}"
+
+#Termination signal to run.sh cleans all child processes
+cleanup() {
+  echo "Cleaning up..."
+  kill $COMPOSE_PID 2>/dev/null || true
+  kill %% 2>/dev/null || true  # Kill background jobs
+  exit 0
+}
+trap cleanup SIGINT SIGTERM EXIT
 
 # How often to *probe* the dashboard when it's down / between attempts
 REREGISTER_INTERVAL_SEC="${REREGISTER_INTERVAL_SEC:-15}"

--- a/run.sh
+++ b/run.sh
@@ -1,17 +1,36 @@
 #!/bin/bash
 
+# -------------------------
+# Config (override via env)
+# -------------------------
+CART_NAME="${CART_NAME:-james}"
+SERVER_IP="${SERVER_IP:-10.247.225.41}" # Current ZeroTier IP for dashboard
+CART_PORT="${CART_PORT:-9090}" # Default rosbridge port
+API_PORT="${API_PORT:-8000}" # Port for dashboard server
+
 bash ./initialize_host.sh
 
 open_browser_when_ready () {
 	until curl -s http://localhost:5173 > /dev/null
 	do
-	# This is just waiting for the application to start. If the container is not up and running, this will wait forever.
-	#   echo "Waiting for port 5173 to open."
 	  sleep 2
 	done
 	open http://localhost:5173
 }
 
-open_browser_when_ready & docker compose up backend frontend --build --remove-orphans --force-recreate 
+register_cart_when_ready () {
+  # Wait until the server answers on port 8000 (adjust path if needed)
+  until curl -s "http://${SERVER_IP}:${API_PORT}/" > /dev/null
+  do
+    sleep 2
+  done
 
+  curl -X POST "http://${SERVER_IP}:${API_PORT}/api/vehicles/register" \
+    -H "Content-Type: application/json" \
+    -d "{\"name\":\"${CART_NAME}\",\"port\":${CART_PORT}}"
+}
 
+open_browser_when_ready &
+register_cart_when_ready &
+
+docker compose up backend frontend --build --remove-orphans --force-recreate

--- a/run.sh
+++ b/run.sh
@@ -10,9 +10,9 @@ CART_PORT="${CART_PORT:-9090}"
 API_PORT="${API_PORT:-8000}"
 
 # How often to *probe* the dashboard when it's down / between attempts
-REREGISTER_INTERVAL_SEC="${REREGISTER_INTERVAL_SEC:-30}"
+REREGISTER_INTERVAL_SEC="${REREGISTER_INTERVAL_SEC:-15}"
 # Minimum time between successful registrations
-REGISTER_COOLDOWN_SEC="${REGISTER_COOLDOWN_SEC:-300}"   # 5 minutes
+REGISTER_COOLDOWN_SEC="${REGISTER_COOLDOWN_SEC:-15}"   # 15 seconds
 
 bash ./initialize_host.sh
 

--- a/run.sh
+++ b/run.sh
@@ -17,22 +17,23 @@ REGISTER_COOLDOWN_SEC="${REGISTER_COOLDOWN_SEC:-15}"   # 15 seconds
 bash ./initialize_host.sh
 
 wait_for_frontend () {
-  until curl -fsS http://localhost:5173 >/dev/null; do
+  until curl -fsS http://localhost:5173 >/dev/null 2>&1; do
     sleep 2
   done
 }
 
 dashboard_up () {
-  curl -fsS "http://${SERVER_IP}:${API_PORT}/" >/dev/null
+  # Only check, don't fail script if dashboard is unreachable
+  curl -fsS "http://${SERVER_IP}:${API_PORT}/" >/dev/null 2>&1
 }
 
 register_cart () {
+  # Ignore failure, always return true
   curl -fsS -X POST "http://${SERVER_IP}:${API_PORT}/api/vehicles/register" \
     -H "Content-Type: application/json" \
-    -d "{\"name\":\"${CART_NAME}\",\"port\":${CART_PORT}}"
+    -d "{\"name\":\"${CART_NAME}\",\"port\":${CART_PORT}}" >/dev/null 2>&1 || true
 }
 
-# Background loop: if dashboard is up, try (re)registering occasionally
 reregister_loop () {
   local last_ok=0
   while true; do
@@ -42,9 +43,8 @@ reregister_loop () {
 
       # only re-register if we haven't done so recently
       if (( now - last_ok >= REGISTER_COOLDOWN_SEC )); then
-        if register_cart; then
-          last_ok="$now"
-        fi
+        register_cart
+        last_ok="$now"
       fi
     fi
 

--- a/run.sh
+++ b/run.sh
@@ -6,8 +6,13 @@ set -e
 # -------------------------
 CART_NAME="${CART_NAME:-james}"
 SERVER_IP="${SERVER_IP:-10.247.225.41}"   # Dashboard server (external)
-CART_PORT="${CART_PORT:-9090}"            # rosbridge port
-API_PORT="${API_PORT:-8000}"              # dashboard server port
+CART_PORT="${CART_PORT:-9090}"
+API_PORT="${API_PORT:-8000}"
+
+# How often to *probe* the dashboard when it's down / between attempts
+REREGISTER_INTERVAL_SEC="${REREGISTER_INTERVAL_SEC:-30}"
+# Minimum time between successful registrations
+REGISTER_COOLDOWN_SEC="${REGISTER_COOLDOWN_SEC:-300}"   # 5 minutes
 
 bash ./initialize_host.sh
 
@@ -17,11 +22,8 @@ wait_for_frontend () {
   done
 }
 
-wait_for_dashboard () {
-  # external dashboard server availability check
-  until curl -fsS "http://${SERVER_IP}:${API_PORT}/" >/dev/null; do
-    sleep 2
-  done
+dashboard_up () {
+  curl -fsS "http://${SERVER_IP}:${API_PORT}/" >/dev/null
 }
 
 register_cart () {
@@ -30,22 +32,36 @@ register_cart () {
     -d "{\"name\":\"${CART_NAME}\",\"port\":${CART_PORT}}"
 }
 
+# Background loop: if dashboard is up, try (re)registering occasionally
+reregister_loop () {
+  local last_ok=0
+  while true; do
+    if dashboard_up; then
+      local now
+      now="$(date +%s)"
+
+      # only re-register if we haven't done so recently
+      if (( now - last_ok >= REGISTER_COOLDOWN_SEC )); then
+        if register_cart; then
+          last_ok="$now"
+        fi
+      fi
+    fi
+
+    sleep "$REREGISTER_INTERVAL_SEC"
+  done
+}
+
 # Start containers
 docker compose up backend frontend --build --remove-orphans --force-recreate &
 COMPOSE_PID=$!
 
-# Wait for the frontend dev server, then open browser
+# Wait for frontend then open browser
 wait_for_frontend
 open "http://localhost:5173"
 
-# After browser opens: wait for dashboard, then register (without blocking compose logs)
-(
-  wait_for_dashboard
-  # optionally retry registration until it works
-  until register_cart; do
-    sleep 2
-  done
-) &
+# Start periodic re-registration in background
+reregister_loop &
 
-# Keep attached to docker compose
+# Keep attached to compose
 wait "$COMPOSE_PID"

--- a/run.sh
+++ b/run.sh
@@ -1,36 +1,48 @@
 #!/bin/bash
+set -e
 
 # -------------------------
 # Config (override via env)
 # -------------------------
 CART_NAME="${CART_NAME:-james}"
-SERVER_IP="${SERVER_IP:-10.247.225.41}" # Current ZeroTier IP for dashboard
-CART_PORT="${CART_PORT:-9090}" # Default rosbridge port
-API_PORT="${API_PORT:-8000}" # Port for dashboard server
+SERVER_IP="${SERVER_IP:-10.247.225.41}"
+CART_PORT="${CART_PORT:-9090}"
+API_PORT="${API_PORT:-8000}"
 
 bash ./initialize_host.sh
 
-open_browser_when_ready () {
-	until curl -s http://localhost:5173 > /dev/null
-	do
-	  sleep 2
-	done
-	open http://localhost:5173
-}
-
-register_cart_when_ready () {
-  # Wait until the server answers on port 8000 (adjust path if needed)
-  until curl -s "http://${SERVER_IP}:${API_PORT}/" > /dev/null
-  do
+wait_for_frontend () {
+  until curl -fsS http://localhost:5173 >/dev/null; do
     sleep 2
   done
+}
 
-  curl -X POST "http://${SERVER_IP}:${API_PORT}/api/vehicles/register" \
+wait_for_backend () {
+  # waits until the backend API is answering
+  until curl -fsS "http://${SERVER_IP}:${API_PORT}/" >/dev/null; do
+    sleep 2
+  done
+}
+
+register_cart () {
+  curl -fsS -X POST "http://${SERVER_IP}:${API_PORT}/api/vehicles/register" \
     -H "Content-Type: application/json" \
     -d "{\"name\":\"${CART_NAME}\",\"port\":${CART_PORT}}"
 }
 
-open_browser_when_ready &
-register_cart_when_ready &
+# Start containers, but keep the script running
+docker compose up backend frontend --build --remove-orphans --force-recreate &
+COMPOSE_PID=$!
 
-docker compose up backend frontend --build --remove-orphans --force-recreate
+# Wait specifically for backend to be usable (not for docker compose to "finish", because `up` runs forever)
+wait_for_backend
+
+# Optionally also wait for frontend before opening browser
+wait_for_frontend
+open "http://localhost:5173"
+
+# Now that backend is up, do the API call
+register_cart
+
+# Keep streaming compose logs / keep containers attached like normal
+wait "$COMPOSE_PID"

--- a/run.sh
+++ b/run.sh
@@ -5,9 +5,9 @@ set -e
 # Config (override via env)
 # -------------------------
 CART_NAME="${CART_NAME:-james}"
-SERVER_IP="${SERVER_IP:-10.247.225.41}"
-CART_PORT="${CART_PORT:-9090}"
-API_PORT="${API_PORT:-8000}"
+SERVER_IP="${SERVER_IP:-10.247.225.41}"   # Dashboard server (external)
+CART_PORT="${CART_PORT:-9090}"            # rosbridge port
+API_PORT="${API_PORT:-8000}"              # dashboard server port
 
 bash ./initialize_host.sh
 
@@ -17,8 +17,8 @@ wait_for_frontend () {
   done
 }
 
-wait_for_backend () {
-  # waits until the backend API is answering
+wait_for_dashboard () {
+  # external dashboard server availability check
   until curl -fsS "http://${SERVER_IP}:${API_PORT}/" >/dev/null; do
     sleep 2
   done
@@ -30,19 +30,22 @@ register_cart () {
     -d "{\"name\":\"${CART_NAME}\",\"port\":${CART_PORT}}"
 }
 
-# Start containers, but keep the script running
+# Start containers
 docker compose up backend frontend --build --remove-orphans --force-recreate &
 COMPOSE_PID=$!
 
-# Wait specifically for backend to be usable (not for docker compose to "finish", because `up` runs forever)
-wait_for_backend
-
-# Optionally also wait for frontend before opening browser
+# Wait for the frontend dev server, then open browser
 wait_for_frontend
 open "http://localhost:5173"
 
-# Now that backend is up, do the API call
-register_cart
+# After browser opens: wait for dashboard, then register (without blocking compose logs)
+(
+  wait_for_dashboard
+  # optionally retry registration until it works
+  until register_cart; do
+    sleep 2
+  done
+) &
 
-# Keep streaming compose logs / keep containers attached like normal
+# Keep attached to docker compose
 wait "$COMPOSE_PID"

--- a/run.sh
+++ b/run.sh
@@ -1,13 +1,21 @@
 #!/bin/bash
 set -e
 
-# -------------------------
+
 # Config (override via env)
-# -------------------------
 CART_NAME="${CART_NAME:-james}"
 SERVER_IP="${SERVER_IP:-10.247.225.41}"   # Dashboard server (external)
 CART_PORT="${CART_PORT:-9090}"
 API_PORT="${API_PORT:-8000}"
+
+#Termination signal to run.sh cleans all child processes
+cleanup() {
+  echo "Cleaning up..."
+  kill $COMPOSE_PID 2>/dev/null || true
+  kill %% 2>/dev/null || true  # Kill background jobs
+  exit 0
+}
+trap cleanup SIGINT SIGTERM EXIT
 
 # How often to *probe* the dashboard when it's down / between attempts
 REREGISTER_INTERVAL_SEC="${REREGISTER_INTERVAL_SEC:-15}"

--- a/services/backend/Dockerfile
+++ b/services/backend/Dockerfile
@@ -81,6 +81,7 @@ RUN set -eux; \
     ros-jazzy-rosbridge-server \
     ros-jazzy-tf-transformations \
     ros-jazzy-pointcloud-to-laserscan \
+    ros-jazzy-tf2-tools \
     python3-transforms3d \
     python3-networkx \
     python3-serial \

--- a/services/backend/Dockerfile
+++ b/services/backend/Dockerfile
@@ -105,7 +105,8 @@ RUN python3 -m pip uninstall --break-system-packages -y numpy
 WORKDIR ${ROS_WS}/src
 # needed for anomaly_msg type dependency
 RUN git clone https://github.com/JACart2/anomaly_detection.git
-RUN git clone --branch 0.2.1-jazzy https://github.com/rsasaki0109/lidar_localization_ros2.git
+# This should be changed later when this repo has a new stable release, (i.e. a stable release after this date 6/15/26)
+RUN git clone --revision=ca80f9f4b201456fc5b9d74f171d6b449ca6a85c --depth=1 https://github.com/rsasaki0109/lidar_localization_ros2.git
 RUN git clone https://github.com/rsasaki0109/ndt_omp_ros2.git
 RUN git clone --recursive --depth 1 --branch "${ZED_ROS2_WRAPPER_TAG}" https://github.com/stereolabs/zed-ros2-wrapper.git 
 RUN git clone https://github.com/stereolabs/zed-ros2-examples.git

--- a/services/backend/Dockerfile
+++ b/services/backend/Dockerfile
@@ -110,7 +110,7 @@ RUN git clone --recursive --depth 1 --branch "${ZED_ROS2_WRAPPER_TAG}" https://g
 RUN git clone https://github.com/stereolabs/zed-ros2-examples.git
 
 # This should be changed later when this repo has a new stable release, (i.e. a stable release after this date 6/15/26)
-ARG LIDAR_LOCALIZATION_COMMIT=ca80f9f4b201456fc5b9d74f171d6b449ca6a85c
+ARG LIDAR_LOCALIZATION_COMMIT=64446b319a789799e7285905b98f38326ea39b9d
 RUN git clone https://github.com/rsasaki0109/lidar_localization_ros2.git && \
     cd lidar_localization_ros2 && \
     git checkout ${LIDAR_LOCALIZATION_COMMIT}

--- a/services/backend/Dockerfile
+++ b/services/backend/Dockerfile
@@ -109,9 +109,9 @@ RUN git clone https://github.com/rsasaki0109/ndt_omp_ros2.git
 RUN git clone --recursive --depth 1 --branch "${ZED_ROS2_WRAPPER_TAG}" https://github.com/stereolabs/zed-ros2-wrapper.git 
 RUN git clone https://github.com/stereolabs/zed-ros2-examples.git
 
-# This should be changed later when this repo has a new stable release, (i.e. a stable release after this date 6/15/26)
-ARG LIDAR_LOCALIZATION_COMMIT=64446b319a789799e7285905b98f38326ea39b9d
-RUN git clone https://github.com/rsasaki0109/lidar_localization_ros2.git && \
+# Pinned to jazzy branch HEAD; upstream main was force-pushed with unrelated research code
+ARG LIDAR_LOCALIZATION_COMMIT=7bf46778767b5544c345a0ef6676cc676c8e6130
+RUN git clone --branch jazzy https://github.com/rsasaki0109/lidar_localization_ros2.git && \
     cd lidar_localization_ros2 && \
     git checkout ${LIDAR_LOCALIZATION_COMMIT}
 WORKDIR ${ROS_WS}

--- a/services/backend/Dockerfile
+++ b/services/backend/Dockerfile
@@ -105,12 +105,15 @@ RUN python3 -m pip uninstall --break-system-packages -y numpy
 WORKDIR ${ROS_WS}/src
 # needed for anomaly_msg type dependency
 RUN git clone https://github.com/JACart2/anomaly_detection.git
-# This should be changed later when this repo has a new stable release, (i.e. a stable release after this date 6/15/26)
-RUN git clone --revision=ca80f9f4b201456fc5b9d74f171d6b449ca6a85c --depth=1 https://github.com/rsasaki0109/lidar_localization_ros2.git
 RUN git clone https://github.com/rsasaki0109/ndt_omp_ros2.git
 RUN git clone --recursive --depth 1 --branch "${ZED_ROS2_WRAPPER_TAG}" https://github.com/stereolabs/zed-ros2-wrapper.git 
 RUN git clone https://github.com/stereolabs/zed-ros2-examples.git
 
+# This should be changed later when this repo has a new stable release, (i.e. a stable release after this date 6/15/26)
+ARG LIDAR_LOCALIZATION_COMMIT=ca80f9f4b201456fc5b9d74f171d6b449ca6a85c
+RUN git clone https://github.com/rsasaki0109/lidar_localization_ros2.git && \
+    cd lidar_localization_ros2 && \
+    git checkout ${LIDAR_LOCALIZATION_COMMIT}
 WORKDIR ${ROS_WS}
 
 

--- a/services/backend/Dockerfile
+++ b/services/backend/Dockerfile
@@ -105,7 +105,7 @@ RUN python3 -m pip uninstall --break-system-packages -y numpy
 WORKDIR ${ROS_WS}/src
 # needed for anomaly_msg type dependency
 RUN git clone https://github.com/JACart2/anomaly_detection.git
-RUN git clone https://github.com/rsasaki0109/lidar_localization_ros2.git
+RUN git clone --branch 0.2.1-jazzy https://github.com/rsasaki0109/lidar_localization_ros2.git
 RUN git clone https://github.com/rsasaki0109/ndt_omp_ros2.git
 RUN git clone --recursive --depth 1 --branch "${ZED_ROS2_WRAPPER_TAG}" https://github.com/stereolabs/zed-ros2-wrapper.git 
 RUN git clone https://github.com/stereolabs/zed-ros2-examples.git

--- a/services/frontend/entrypoint.sh
+++ b/services/frontend/entrypoint.sh
@@ -11,7 +11,7 @@ if [ -d ".git" ]; then
 fi
 
 echo "Installing npm dependencies..."
-npm install
+npm ci --prefer-offline --no-audit
 
 if [[ -n "$FRONTEND_COMMAND" ]]; then
   exec bash -lc "$FRONTEND_COMMAND"


### PR DESCRIPTION
# Pull Request

## Linked Issue
Closes N/A

---

# Summary
Adds cart self-registration with the dashboard server (periodic re-registration loop in `run.sh` and `dev-run-backend.sh`), pins the `lidar_localization_ros2` dependency to certain commit hash, adds `ros-jazzy-tf2-tools` to the backend image, switches frontend dependency installation to `npm ci`, and reworks `run.sh`/`dev-run-anomaly-detection.sh`/`dev-run-backend.sh` with cleanup traps, frontend-ready waits, and offline-aware compose flags.

---

# Testing Summary

- Testing process: Ran `run.sh` on the cart with the dashboard server reachable at `SERVER_IP`/`API_PORT`, confirmed `docker compose up backend frontend` builds and starts, the browser opens once the frontend is ready, and the cart successfully POSTs to `/api/vehicles/register` on the re-register interval. Ran `dev-run-backend.sh` and `dev-run-anomaly-detection.sh` to confirm the dev containers still build and attach a terminal correctly. Verified the anomaly detection container builds with the new Python dependencies and starts without referencing `OA_SECRET.txt`. Confirmed `Ctrl+C` on `run.sh` triggers `cleanup` and tears down the compose process and background jobs.
- Observed results: Cart registers with the dashboard within `REREGISTER_INTERVAL_SEC` (default 15s) and re-registers only after `REGISTER_COOLDOWN_SEC`; registration attempts fail silently (no script crash) when the dashboard is unreachable.
- Edge cases explored: Dashboard server unreachable at startup (script continues without error, retries on interval); running `run.sh` with no internet connectivity using `--pull=never` in the dev scripts (cached images used successfully); `Ctrl+C` during container startup (cleanup trap kills compose and background jobs without leaving orphaned processes).

---

# Testing Instructions
Reviewers are typically not required to live test on the cart.

1. Set environment variables as needed: `CART_NAME`, `SERVER_IP`, `CART_PORT`, `API_PORT` (defaults: `madison`/`james`, `10.247.225.41`, `9090`, `8000`).
2. Run `./run.sh` (or `./dev-run-backend.sh` / `./dev-run-anomaly-detection.sh` for dev workflows).
3. Launch files used: `cart_launch autonomous_launcher.launch.py` (with `cart_madison.yaml` config in `dev-run-anomaly-detection.sh`), `anomaly_detection anomaly_detection.launch.py`.
4. Topics/services to monitor: HTTP `POST http://${SERVER_IP}:${API_PORT}/api/vehicles/register` (watch dashboard server logs for incoming registration requests), `http://localhost:5173` (frontend readiness), `http://localhost:5000` (anomaly detection service, opened in `dev-run-anomaly-detection.sh`).
5. Expected output/behavior: `docker compose up backend frontend` builds and starts containers; once `localhost:5173` responds, a browser tab opens automatically; every ~15 seconds (if the dashboard is reachable) a registration POST is sent with `{"name": "<CART_NAME>", "port": <CART_PORT>}`; pressing `Ctrl+C` cleanly stops the compose process and background loops via the `cleanup` trap. connection as active with the configured static IP; `systemctl status velodyne-net.service` should no longer exist/be referenced.
6. Conditions under which failure should occur: if `SERVER_IP`/`API_PORT` point to a dashboard that is down, registration requests should fail silently (curl exits non-zero, ignored via `|| true`) without halting the script; if `nmcli` is unavailable, 
---

# Success Metrics (From Issue)
- [ ] Metric 1: Cart automatically registers itself with the dashboard server on startup and periodically re-registers without manual intervention.


---

# Integration Impact
Yes. This affects multiple subsystems:
- The backend's network registration now depends on an external dashboard server being reachable at `SERVER_IP:API_PORT`; if the dashboard API changes its `/api/vehicles/register` contract, both `run.sh` and `dev-run-backend.sh` will need updating.
- Pinning `lidar_localization_ros2` to commit hash changes the localization stack version used by the backend image — any code relying on newer/older behavior from that package should be re-verified.
- Switching `npm install` to `npm ci` in the frontend entrypoint requires `package-lock.json` to be present and in sync with `package.json`, or the frontend build will fail.